### PR TITLE
housekeeping: Add PackageIconUrl

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <NoWarn>$(NoWarn);VSX1000</NoWarn>
@@ -16,6 +16,7 @@
     <!-- Optional: Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <!-- disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
+    <PackageIconUrl>https://raw.githubusercontent.com/reactiveui/styleguide/master/logo_fusillade/main.png?raw=true</PackageIconUrl>
   </PropertyGroup>
   <PropertyGroup Condition="$(IsTestProject)">
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

After we publish a new Fusillade version, it should show an icon in the NuGet package manager GUI.